### PR TITLE
Format comment to html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "jodit": "^4.11.15",
-        "react": "^19.2.4"
+        "react": "^19.2.4",
+        "showdown": "^2.1.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
@@ -1545,6 +1546,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3176,6 +3186,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/showdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.0.0"
+      },
+      "bin": {
+        "showdown": "bin/showdown.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/tiviesantos"
       }
     },
     "node_modules/signal-exit": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   },
   "dependencies": {
     "jodit": "^4.11.15",
-    "react": "^19.2.4"
+    "react": "^19.2.4",
+    "showdown": "^2.1.0"
   }
 }

--- a/src/Comment.ts
+++ b/src/Comment.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { CommentManager } from "./CommentManager";
-import { Panel } from "./Panel";
 import { NoteManager } from "./NoteManager";
+import { Console } from "console";
 
 export class Comment{
     /**
@@ -36,7 +36,14 @@ export class Comment{
                 commentWOslash = commentWOslash + parts[i];
             }
         }
-        
+
+        // Convert markdown comment to HTML for Carrot Notes
+        var showdown  = require('showdown'),
+            converter = new showdown.Converter(),
+            text      = commentWOslash,
+            html      = converter.makeHtml(text);
+
+        console.log(html);
 
         //Removes highlighted text
         const removed = await editor.edit(editBuilder => {
@@ -52,7 +59,7 @@ export class Comment{
         }
 
         // Create a serialized note for the comment and returns it id
-        const noteId = await NoteManager.getInstance(context.workspaceState).addNote(editor.document.uri, commentWOslash);
+        const noteId = await NoteManager.getInstance(context.workspaceState).addNote(editor.document.uri, html);
 
         // Add the new comment to the comment manager with the new note id
         CommentManager.getInstance(context.workspaceState).addComment(noteId, editor.document.uri, decorationLine, commentWOslash);

--- a/src/Comment.ts
+++ b/src/Comment.ts
@@ -27,20 +27,29 @@ export class Comment{
             return false;
         }
 
-        //Remove '//' from comment
-        let parts = comment.split("//");
-        let commentWOslash = "";
+        //Remove '// ' from comment
+        let parts = comment.split("// ");
+        let commentWOslashspace = "";
         let size = parts.length;
         for (let i = 0; i < size; i++){
             if (parts[i] !== "//") {
-                commentWOslash = commentWOslash + parts[i];
+                commentWOslashspace = commentWOslashspace + parts[i];
+            }
+        }
+        //Remove '//' from comment
+        let parts2 = commentWOslashspace.split("//");
+        let commentWOslashes = "";
+        let size2 = parts2.length;
+        for (let i = 0; i < size2; i++){
+            if (parts2[i] !== "//") {
+                commentWOslashes = commentWOslashes + parts2[i];
             }
         }
 
         // Convert markdown comment to HTML for Carrot Notes
         var showdown  = require('showdown'),
             converter = new showdown.Converter(),
-            text      = commentWOslash,
+            text      = commentWOslashes,
             html      = converter.makeHtml(text);
 
         console.log(html);
@@ -62,7 +71,7 @@ export class Comment{
         const noteId = await NoteManager.getInstance(context.workspaceState).addNote(editor.document.uri, html);
 
         // Add the new comment to the comment manager with the new note id
-        CommentManager.getInstance(context.workspaceState).addComment(noteId, editor.document.uri, decorationLine, commentWOslash);
+        CommentManager.getInstance(context.workspaceState).addComment(noteId, editor.document.uri, decorationLine, commentWOslashes);
         
         vscode.window.showInformationMessage("Carrot Comment created successfully!");
         return true;

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -4,11 +4,44 @@ import 'jodit/es2021/jodit.min.css';
 import { Jodit } from 'jodit';
 import 'jodit/esm/plugins/resizer/resizer';
 import 'jodit/esm/plugins/image/image';
+//import 'jodit/esm/plugins/paragraph-style/paragraph-style'; // Wrong
+//import 'jodit/esm/plugins/list/list';               // Wrong
+import 'jodit/esm/plugins/format-block/format-block'; // Handles H1, H2, etc.
+import 'jodit/esm/plugins/ordered-list/ordered-list'; 
+import 'jodit/esm/plugins/indent/indent';           // Helps with list spacing
+import 'jodit/esm/plugins/font/font';               // Fixes Size/Color logic
+import 'jodit/esm/plugins/color/color';             // Enables color switching
 
 // Initialize Jodit
 const editor = Jodit.make('#editor', {
     height: '100%',
     autofocus: true,
+    iframe: true,
+
+    // buttons: [
+    //     'bold', 'italic', 'underline', '|', 
+    //     'ul', 'ol', '|', 
+    //     'paragraph', 'fontsize', 'brush', '|',
+    //     'image', 'table', 'link', 'hr', 'undo', 'redo'
+    // ],
+
+    style: {
+        color: '#000000',     // Black text
+        fontSize: '12px',     // Size 12
+        fontFamily: 'Arial, sans-serif'
+    },
+
+    // This ensures that even if the webview resets CSS, the editor content looks right
+    iframeStyle: `
+        h1 { font-size: 2em !important; font-weight: bold !important; display: block !important; margin: 0.67em 0; }
+        h2 { font-size: 1.5em !important; font-weight: bold !important; display: block !important; margin: 0.83em 0; }
+        h3 { font-size: 1.17em !important; font-weight: bold !important; display: block !important; margin: 1em 0; }
+        
+        /* Ensure lists have visible bullets and numbers */
+        ul { list-style-type: disc !important; padding-left: 40px !important; margin: 1em 0 !important; }
+        ol { list-style-type: decimal !important; padding-left: 40px !important; margin: 1em 0 !important; }
+        li { display: list-item !important; }
+    `,
     // tells jodit which HTML elements are allowed to be resized by user. By default supports img, table, iframe
     allowResizeTags: new Set(['img', 'table', 'iframe']),
     resizer: {


### PR DESCRIPTION
The markdown comments are successfully reformatted to html and displayed correctly in the jodit text editor