### PR TITLE
Make webview not dependent on workspace state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "carrot",
-  "version": "0.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "carrot",
-      "version": "0.0.1",
+      "version": "1.0.2",
+      "license": "MIT License",
       "dependencies": {
         "jodit": "^4.11.15",
         "react": "^19.2.4",

--- a/src/CommentManager.ts
+++ b/src/CommentManager.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode';
 import { SerializedComment } from './SerializedComment';
-import { SerializedNote } from './SerializedNote';
 import { NoteManager } from './NoteManager';
-import { Comment } from './Comment';
 
 export class CommentManager{
 

--- a/src/NoteManager.ts
+++ b/src/NoteManager.ts
@@ -19,6 +19,13 @@ export class NoteManager {
         return NoteManager.instance;
     }
 
+    public static getInstanceWOWorkspace() : NoteManager {
+        if (!this.instance) {
+            vscode.window.showErrorMessage("Failed to get instance of NoteManager. Restart Extension.");
+        }
+        return NoteManager.instance;
+    }
+
     public async addNote(editorUri: vscode.Uri, hoverMessage: string) : Promise<number> {
         const allNotes = this.workspaceState.get<SerializedNote[]>("notes", []);
 

--- a/src/Panel.ts
+++ b/src/Panel.ts
@@ -10,7 +10,7 @@ export class Panel {
     private _disposables: vscode.Disposable[] = [];
 	private _noteId: number;
 
-    constructor(context: vscode.ExtensionContext, panel: vscode.WebviewPanel, extensionUri: vscode.Uri, noteId: number){
+    constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, noteId: number){
         this._panel = panel;
         this._extensionUri = extensionUri;
 		this._noteId = noteId;
@@ -37,7 +37,7 @@ export class Panel {
 			message => {
 				switch (message.command) {
 					case 'webviewReady':
-						const noteHtml = NoteManager.getInstance(context.workspaceState).loadNote(this._noteId);
+						const noteHtml = NoteManager.getInstanceWOWorkspace().loadNote(this._noteId);
 						this._panel.webview.postMessage({ 
 							command: 'loadNote', 
 							html: noteHtml
@@ -47,7 +47,7 @@ export class Panel {
 						vscode.window.showErrorMessage(message.text);
 						return;
 					case 'contentChanged':
-						NoteManager.getInstance(context.workspaceState).saveNote(this._noteId, this._extensionUri, message.html);
+						NoteManager.getInstanceWOWorkspace().saveNote(this._noteId, this._extensionUri, message.html);
 						return;
 				}
 			},
@@ -103,7 +103,7 @@ export class Panel {
         );
         
         // Set the panel.
-        Panel.currentPanel = new Panel(context, panel, extensionUri, noteId);
+        Panel.currentPanel = new Panel(panel, extensionUri, noteId);
     }
 
     private _update(){

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,9 +4,11 @@ import { Comment } from "./Comment";
 import { Panel } from "./Panel";
 
 import { CommentManager } from './CommentManager';
+import { NoteManager } from './NoteManager';
 
 let carrotDecorationType: vscode.TextEditorDecorationType;
 let commentManager: CommentManager;
+let noteManager: NoteManager;
 
 export async function activate(context: vscode.ExtensionContext) : Promise<vscode.ExtensionContext> {
 	// Create one instance of the decoration type
@@ -16,6 +18,7 @@ export async function activate(context: vscode.ExtensionContext) : Promise<vscod
 
 	// Get the instance of the CommentManager Singleton
 	commentManager = CommentManager.getInstance(context.workspaceState);
+	noteManager = NoteManager.getInstance(context.workspaceState);
 
 	// Listen for changing the tab/file
 	vscode.window.onDidChangeActiveTextEditor(editor => {


### PR DESCRIPTION
Add getinstanceWOworkspacestate to NoteManager.ts
Instantiate note manager in extension.ts to ensure instance is always accessible.

Make sure to test all functionality!